### PR TITLE
Avoid creating a Docker layer containing the compressed model file.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ ARG model_file=assets.tar.gz
 
 WORKDIR /workspace
 
-RUN wget -nv --show-progress --progress=bar:force:noscroll ${model_bucket}/${model_file} --output-document=/workspace/assets/${model_file}
-RUN tar -x -C assets/ -f assets/${model_file} -v && rm assets/${model_file}
+RUN wget -nv --show-progress --progress=bar:force:noscroll ${model_bucket}/${model_file} --output-document=assets/${model_file} && \
+  tar -x -C assets/ -f assets/${model_file} -v && rm assets/${model_file}
 
 COPY requirements.txt /workspace
 RUN pip install -r requirements.txt


### PR DESCRIPTION
Download and delete the compressed model file in the same layer to avoid an (often oversized) additional Docker layer.